### PR TITLE
(documentation) remove warning for fixed issue

### DIFF
--- a/docs/npwd/api/server-exports.mdx
+++ b/docs/npwd/api/server-exports.mdx
@@ -23,10 +23,6 @@ NPWD behavior and actions. You can find a list of the available **server exports
     desc="Adds a new player to NPWD internal handling. This is used with framework integration to load a player."
 />
 
-:::warning
-The export `unloadPlayer` currently doesn't perform correctly due to recoil limitations. You can track the issue [here](https://github.com/project-error/npwd/issues/476).
-:::
-
 <ExportComponent
     name="unloadPlayer"
     luaExample={"exports.npwd:unloadPlayer(source)"}


### PR DESCRIPTION
**Pull Request Description**

removes the "Danger" callout for unloadPlayer that was fixed here: https://github.com/project-error/npwd/issues/476#issuecomment-1081240025

**Pull Request Checklist**:
* [✅] Have you followed the guidelines in our contributing document and Code of Conduct?
* [✅] Have you checked to ensure there aren't other open for the same update/change?
* [❎] Have you built and tested the `resource` in-game after the relevant change?
